### PR TITLE
hide check update dialog if on latest version

### DIFF
--- a/Scripts/components/Panel/SettingsPanel.cs
+++ b/Scripts/components/Panel/SettingsPanel.cs
@@ -798,6 +798,7 @@ public class SettingsPanel : Panel
 			AppDialogs.NewVersion.ShowDialog(rel,true);
 			AppDialogs.NewVersion.Connect("download_manager_update", this, "OnDownloadManagerUpdate");
 		} else {
+			AppDialogs.BusyDialog.HideDialog();
 			AppDialogs.MessageDialog.ShowMessage("Check for Godot Manager Updates","Currently on latest version of Godot Manager.");
 		}
 	}


### PR DESCRIPTION
This fixes a bug where the "Check for updates" dialog is not closed when the manager has the latest version.