### PR TITLE
Support Direct Import of Projects

### DIFF
--- a/Scripts/Scenes/SceneManager.cs
+++ b/Scripts/Scenes/SceneManager.cs
@@ -13,14 +13,7 @@ public class SceneManager : Control
 	public override void _Ready()
 	{
 		string[] args = OS.GetCmdlineArgs();
-		if (args.Length == 0) {
-			OS.MinWindowSize = DEFAULT_RESOLUTION;
-			OS.WindowSize = DEFAULT_RESOLUTION;
-			OS.CenterWindow();
-			MainWindow win = mainWindow.Instance<MainWindow>();
-			AddChild(win);
-			win.Visible = true;
-		} else {
+		if (args.Length > 0 && (args[0] == "--update" || args[0] == "--update-complete")) {
 			OS.MinWindowSize = UPDATE_RESOLUTION;
 			OS.WindowSize = UPDATE_RESOLUTION;
 			OS.CenterWindow();
@@ -29,6 +22,18 @@ public class SceneManager : Control
 			win.Visible = true;
 			win.StartUpdate(args);
 			//win.CallDeferred("StartUpdate",args);
+		} else {
+			OS.MinWindowSize = DEFAULT_RESOLUTION;
+			OS.WindowSize = DEFAULT_RESOLUTION;
+			OS.CenterWindow();
+			MainWindow win = mainWindow.Instance<MainWindow>();
+			AddChild(win);
+			
+			if (args.Length > 0) {
+				AppDialogs.ImportProject.ShowDialog(args[0]);
+			}
+		
+			win.Visible = true;
 		}
 	}
 

--- a/Scripts/components/Dialogs/ImportProject.cs
+++ b/Scripts/components/Dialogs/ImportProject.cs
@@ -58,9 +58,9 @@ public class ImportProject : ReferenceRect
 		}
 	}
 
-	public void ShowDialog() {
+	public void ShowDialog(string location = "") {
         UpdateGodotVersions();
-        _locationValue.Text = "";
+        _locationValue.Text = location;
         _godotVersions.Selected = iDefault;
         Visible = true;
     }


### PR DESCRIPTION
This adds support for importing .godot files by passing it's filename as a startup argument. With this, users should be able to use _open with_ on Windows so that when they click a .godot file it opens in Godot Manager and prompts them to import it as a project.