### PR TITLE
Fix Windows 11 crash - Globalize installation path in GodotInstaller.cs

### DIFF
--- a/libs/util/GodotInstaller.cs
+++ b/libs/util/GodotInstaller.cs
@@ -194,7 +194,7 @@ public class GodotInstaller : Object {
 		if (_version.IsMono)
 			instDir = instDir.GetBaseDir();
 #endif
-		ZipFile.ExtractToDirectory(_version.CacheLocation,instDir);
+		ZipFile.ExtractToDirectory(_version.CacheLocation, ProjectSettings.GlobalizePath(instDir));
 
 		Array<string> fileList = new Array<string>();
 		using (ZipArchive za = ZipFile.OpenRead(_version.CacheLocation.GetOSDir().NormalizePath())) {


### PR DESCRIPTION
Hi, 

Thanks for making this, I am using it as part of my development workflow and it's very nice. The official release of Godot Manager works for me on Windows 10, but when trying on a Windows 11 machine I immediately hit #64. I downloaded the project and debugged the failure. It seems like for some reason the behavior for using a user:// path directly in ZipFile is different on Windows 11

![image](https://github.com/eumario/godot-manager/assets/9920963/9ae10826-108e-4192-906f-52c56f17078b)

After running this change locally, I was able to install versions on 11 without issues. 

Hopefully this fixes #64  for others as well 