### PR TITLE
Fixes a crash when a project is missing a name.

### DIFF
--- a/libs/data/Internal/ProjectFile.cs
+++ b/libs/data/Internal/ProjectFile.cs
@@ -24,11 +24,9 @@ public class ProjectFile : Godot.Object {
 				return projectFile;
 			if (!project.HasSection("application"))
 				return projectFile;
-			if (!project.HasSectionKey("application","config/name"))
-				return projectFile;
 			if (project.GetValue("header","config_version") == "4" || project.GetValue("header","config_version") == "5") {
 				projectFile = new ProjectFile();
-				projectFile.Name = project.GetValue("application", "config/name");
+				projectFile.Name = project.GetValue("application", "config/name", "Unnamed");
 				projectFile.Description = project.GetValue("application", "config/description", projectFile.Tr("No Description"));
 				projectFile.Location = filePath.NormalizePath();
 				projectFile.Icon = project.GetValue("application", "config/icon", "res://icon.png");


### PR DESCRIPTION
I saw there's also a godot4 branch. I can also port this to godot4 as well.

https://github.com/eumario/godot-manager/assets/629422/3793a220-9441-4021-8e4c-98165dff5edd

