### PR TITLE
Prevent crash when drag window on mac

### DIFF
--- a/Scripts/components/Titlebar.cs
+++ b/Scripts/components/Titlebar.cs
@@ -3,6 +3,7 @@ using Godot.Sharp.Extras;
 
 public class Titlebar : Control
 {
+    private bool moving = false;
     private bool following = false;
     private Vector2 start_pos = Vector2.Zero;
     public override void _Ready()
@@ -21,8 +22,10 @@ public class Titlebar : Control
             }
         }
 
-        if (following) {
+        if (following && !moving) {
+            moving = true;
             OS.WindowPosition = OS.WindowPosition + GetLocalMousePosition() - start_pos;
+            moving = false;
         }
     }
 }


### PR DESCRIPTION
fixed #89 
Perhaps it crashes if the window is repositioned further while it is being repositioned. Therefore, the window position can be changed only once at the same time.