### PR TITLE
fix NormalizePath error

### DIFF
--- a/Library/Utility/FileUtil.cs
+++ b/Library/Utility/FileUtil.cs
@@ -30,6 +30,10 @@ public static class FileUtil
 
     public static string NormalizePath(this string path)
     {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return path;
+        }
         var newPath = path.Clone() as string;
         if (path.StartsWith("user://"))
             newPath = ProjectSettings.GlobalizePath(newPath);


### PR DESCRIPTION
When the parameter 'path' is empty, there will be an error